### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/forge_publish.yml
+++ b/.github/workflows/forge_publish.yml
@@ -1,0 +1,22 @@
+name: Puppet Forge publish
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  pdk:
+    name: Validate, build, publish
+    runs-on: ubuntu-latest
+    container:
+      image: puppet/pdk:latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: PDK validate
+      run: pdk validate --parallel
+    - name: PDK build
+      run: pdk build && mv $(ls -d ./pkg/*) ./pkg/module.tar.gz
+    - name: Publish to Puppet Forge
+      uses: call/dockerfile-curl@master
+      with:
+        args: '-D- --fail --silent --show-error --request POST "https://forgeapi.puppet.com/v3/releases" -F "file=@pkg/module.tar.gz" -H "Authorization: Bearer ${{ secrets. FORGE_API_KEY }}"'

--- a/.github/workflows/macos_puppet_apply.yml
+++ b/.github/workflows/macos_puppet_apply.yml
@@ -1,0 +1,37 @@
+name: MacOS puppet apply
+on: [push]
+jobs:
+  pdk:
+    name: Puppet install and apply
+    runs-on: macos-10.15
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Install puppet
+      run: |
+        set -euo pipefail
+        PUPPET_AGENT_BASENAME='puppet-agent-6.11.1-1'
+        PUPPET_MACOS_MAJOR_VERSION='10.14'
+        PUPPET_DMG_URL="https://downloads.puppet.com/mac/puppet6/${PUPPET_MACOS_MAJOR_VERSION}/x86_64/${PUPPET_AGENT_BASENAME}.osx${PUPPET_MACOS_MAJOR_VERSION}.dmg"
+        WORK_DIR=$(mktemp -d)
+
+        echo "Downloading ${PUPPET_AGENT_BASENAME} from downloads.puppetlabs.com..."
+        curl -o "${WORK_DIR}/puppet-agent.dmg" "${PUPPET_DMG_URL}"
+
+        echo "Mounting DMG and installing puppet-agent..."
+        hdiutil attach "${WORK_DIR}/puppet-agent.dmg"
+        sudo installer -package "/Volumes/${PUPPET_AGENT_BASENAME}.osx${PUPPET_MACOS_MAJOR_VERSION}/${PUPPET_AGENT_BASENAME}-installer.pkg" -target /
+        hdiutil detach "/Volumes/${PUPPET_AGENT_BASENAME}.osx${PUPPET_MACOS_MAJOR_VERSION}"
+    - name: Puppet module install & apply
+      run: |
+        set -euo pipefail
+        echo "Creating tarball of puppet-buildkite_agent..."
+        tar -czvf ../module.tar.gz .
+        echo "Installing puppet-buildkite_agent and dependencies..."
+        sudo /opt/puppetlabs/puppet/bin/puppet module install ../module.tar.gz
+
+        echo "Running puppet apply (1 of 2)..."
+        sudo /opt/puppetlabs/puppet/bin/puppet apply -e "include buildkite_agent"
+
+        echo "Running puppet apply (2 of 2)..."
+        sudo /opt/puppetlabs/puppet/bin/puppet apply -e "include buildkite_agent"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,8 @@
+# @summary A short summary of the purpose of this class
+#
+# A description of what this class does
+#
+# @example
+#   include buildkite_agent
+class buildkite_agent {
+}

--- a/spec/classes/buildkite_agent_spec.rb
+++ b/spec/classes/buildkite_agent_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'buildkite_agent' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
This PR encapsulates the following changes:

- Add _Puppet Forge publish_ workflow
  - Workflow is triggered whenever a semver-style (`x.y.z`) tag is pushed to any branch
    1. All PDK validators are run in parallel (metadata, yaml, puppet, ruby, tasks)
    2. PDK builds the puppet module tarball
    3. Module is published to Puppet Forge
  - Developers must manually
    - Bump the module version in metadata.json
    - Add the corresponding version tag, e.g. `git tag 1.4.12`
    - Push the branch & tag to the remote, e.g. `git push origin mybranch && git push origin mybranch --tags`
- Add _MacOS puppet apply_ workflow
  - Workflow is triggered by a push to any branch
    1. Install puppet-agent from `downloads.puppet.com` pkgdmg
    2. Create module tarball
    3. Install module with `sudo puppet module install`
    4. Run `sudo puppet apply -e` to run inline puppet code; include the module's main class
    5. Run the same `puppet apply` command again to ensure all config drift has been corrected
- Add an empty main class generated with `pdk new class buildkite_agent`