### PR TITLE
Add buildkite version custom fact

### DIFF
--- a/lib/facter/buildkite_agent_version.rb
+++ b/lib/facter/buildkite_agent_version.rb
@@ -1,0 +1,16 @@
+require 'mkmf'
+
+# Silences mkmf
+module MakeMakefile::Logging
+  @logfile = File::NULL
+  @quiet = true
+end
+
+Facter.add(:buildkite_agent_version) do
+  confine kernel: ['Darwin']
+  setcode do
+    if find_executable 'buildkite-agent'
+      `buildkite-agent --version`.split(' ')[2].chomp(',')
+    end
+  end
+end


### PR DESCRIPTION
Add a custom fact to return the version of the Buildkite binary. Currently supports macOS only.