### PR TITLE
Add install manifest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,684 @@
+require:
+  rubocop-i18n
+
+AllCops:
+  Include:
+    - 'lib/**/*.rb'
+    - 'ext/**/*.rb'
+  Exclude:
+    - '**/*.erb'
+    - 'acceptance/**/*'
+    - 'spec/**/*'
+    - 'tasks/**/*'
+    - 'ext/suse/puppet.spec'
+    - 'lib/puppet/vendor/**/*'
+    - 'lib/puppet/pops/parser/eparser.rb'
+    - 'Rakefile'
+    - 'Gemfile'
+
+# MAYBE useful - no return inside ensure block.
+Lint/EnsureReturn:
+  Enabled: false
+
+# MAYBE useful - errors when rescue {} happens.
+Lint/HandleExceptions:
+  Enabled: false
+
+# DISABLED really useless. Detects return as last statement.
+Style/RedundantReturn:
+  Enabled: false
+
+# Disabled. Throws an error trying to run.
+Style/RedundantParentheses:
+  Enabled: false
+
+# DISABLED since the instances do not seem to indicate any specific errors.
+Lint/AmbiguousOperator:
+  Enabled: false
+
+# DISABLED - not useful
+Layout/SpaceBeforeComment:
+  Enabled: false
+
+# DISABLED - not useful
+Style/HashSyntax:
+  Enabled: false
+
+# USES: as shortcut for non nil&valid checking a = x() and a.empty?
+# DISABLED - not useful
+Style/AndOr:
+  Enabled: false
+
+# DISABLED - not useful
+Style/RedundantSelf:
+  Enabled: false
+
+# DISABLED - not useful
+Metrics/MethodLength:
+  Enabled: false
+
+# DISABLED - not useful
+Style/WhileUntilModifier:
+  Enabled: false
+
+# DISABLED - the offender is just haskell envy
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+# DISABLED
+Security/Eval:
+  Enabled: false
+# DISABLED
+Lint/BlockAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/DefEndAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/EndAlignment:
+  Enabled: false
+
+# DISABLED
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Lint/RescueException:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Layout/AccessModifierIndentation:
+  Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+Layout/AlignArray:
+  Enabled: false
+
+Layout/AlignHash:
+  Enabled: false
+
+Layout/AlignParameters:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/Attr:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Layout/CaseIndentation:
+  Enabled: false
+
+Style/CharacterLiteral:
+  Enabled: false
+
+Style/ClassAndModuleCamelCase:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/ClassMethods:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+Style/WhenThen:
+  Enabled: false
+
+
+# DISABLED - not useful
+Style/WordArray:
+  Enabled: false
+
+Style/UnneededPercentQ:
+  Enabled: false
+
+Layout/Tab:
+  Enabled: false
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: false
+
+Layout/TrailingBlankLines:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideBrackets:
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Layout/SpaceInsideParens:
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Enabled: false
+
+Layout/SpaceAfterColon:
+  Enabled: false
+
+Layout/SpaceAfterComma:
+  Enabled: false
+
+Layout/SpaceAroundKeyword:
+  Enabled: false
+
+Layout/SpaceAfterMethodName:
+  Enabled: false
+
+Layout/SpaceAfterNot:
+  Enabled: false
+
+Layout/SpaceAfterSemicolon:
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Enabled: false
+
+
+Style/CollectionMethods:
+  Enabled: false
+
+Layout/CommentIndentation:
+  Enabled: false
+
+Style/ColonMethodCall:
+  Enabled: false
+
+Style/CommentAnnotation:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Style/ConstantName:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DefWithParentheses:
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Enabled: false
+
+Layout/DotPosition:
+  Enabled: false
+
+# DISABLED - used for converting to bool
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentHash:
+  Enabled: false
+
+Layout/IndentationConsistency:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/EmptyLines:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+
+Style/EmptyLiteral:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: false
+
+Style/MethodDefParentheses:
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Enabled: false
+
+Layout/TrailingWhitespace:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/GlobalVars:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/MultilineIfThen:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: false
+
+Style/NegatedWhile:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SingleLineMethods:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+
+Style/TrivialAccessors:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: false
+
+Style/VariableInterpolation:
+  Enabled: false
+
+Style/VariableName:
+  Enabled: false
+
+Style/WhileUntilDo:
+  Enabled: false
+
+Style/EvenOdd:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/For:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/MethodName:
+  Enabled: false
+
+Style/MultilineTernaryOperator:
+  Enabled: false
+
+Style/NestedTernaryOperator:
+  Enabled: false
+
+Style/NilComparison:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: false
+
+Style/Semicolon:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/NonNilCheck:
+  Enabled: false
+
+Style/Not:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/OneLineConditional:
+  Enabled: false
+
+Style/OpMethod:
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/PredicateName:
+  Enabled: false
+
+Style/RedundantException:
+  Enabled: false
+
+Style/SelfAssignment:
+  Enabled: false
+
+Style/Proc:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/RedundantBegin:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Lint/RequireParentheses:
+  Enabled: false
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/IfWithSemicolon:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: false
+
+Style/InfiniteLoop:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  Enabled: false
+
+Style/PercentQLiterals:
+  Enabled: false
+
+Layout/MultilineBlockLayout:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Style/UnneededInterpolation:
+  Enabled: false
+
+Layout/ElseAlignment:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Layout/IndentAssignment:
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/CommandLiteral:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Layout/RescueEnsureAlignment:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Enabled: false
+
+Layout/InitialIndentation:
+  Enabled: false
+
+Style/StructInheritance:
+  Enabled: false
+
+Style/SymbolLiteral:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/MultilineArrayBraceLayout:
+  Enabled: false
+
+Layout/MultilineHashBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Enabled: false
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: false
+
+Lint/EmptyWhen:
+  Enabled: false
+
+Lint/InheritException:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false
+
+Style/MethodMissing:
+  Enabled: false
+
+Style/MixinGrouping:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/MultilineMemoization:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/NumericLiteralPrefix:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/YodaCondition:
+  Enabled: false
+
+GetText/DecorateFunctionMessage:
+  Enabled: false
+
+GetText/DecorateString:
+  Enabled: false
+
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ PLATFORMS
 DEPENDENCIES
   fast_gettext
   json (= 2.1.0)
-  puppet
+  puppet (= 6.11.1)
   puppet-module-posix-default-r2.5 (~> 0.3)
   puppet-module-posix-dev-r2.5 (~> 0.3)
   puppet-module-win-default-r2.5 (~> 0.3)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,8 @@
+# @summary A short summary of the purpose of this class
+#
+# A description of what this class does
+#
+# @example
+#   include buildkite_agent::install
+class buildkite_agent::install {
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,49 @@
-# @summary A short summary of the purpose of this class
+# @summary Installs Buildkite agent
 #
-# A description of what this class does
+# Installs the buildkite-agent binary on macOS
 #
 # @example
 #   include buildkite_agent::install
-class buildkite_agent::install {
+class buildkite_agent::install (
+  String[1] $package_name   = 'buildkite-agent-darwin-amd64',
+  String[1] $package_ensure = '3.19.0',
+  String[1] $repository_url = 'https://github.com/buildkite/agent/releases/download/',
+  String[1] $archive_name   = "${package_name}-${package_ensure}.tar.gz",
+  String[1] $package_source = "${repository_url}/v${package_ensure}/${archive_name}",
+) {
+
+  $bk_version = $facts['buildkite_agent_version']
+
+  if $bk_version and (versioncmp($bk_version, $package_ensure) == 0) {
+    notify{ "Buildkite-agent ${package_ensure} is installed as specified.": }
+  } else {
+    notify{ "Buildkite-agent ${package_ensure} not installed, installing...": }
+
+    file {"/tmp/${archive_name}-untar":
+      ensure => directory,
+    }
+
+    archive { $archive_name:
+      path         => "/tmp/${archive_name}",
+      source       => $package_source,
+      extract      => true,
+      extract_path => "/tmp/${archive_name}-untar",
+      cleanup      => false
+    }
+
+    exec { 'cp_buildkite_agent':
+      command     => "/bin/cp /tmp/${archive_name}-untar/buildkite-agent /usr/local/bin/buildkite-agent",
+      subscribe   => Archive[$archive_name],
+      refreshonly => true,
+      before      => File['/usr/local/bin/buildkite-agent'],
+    }
+
+    file { '/usr/local/bin/buildkite-agent':
+      ensure => 'present',
+      owner  => 'root',
+      group  => 'admin',
+      mode   => '0755',
+    }
+  }
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,7 +28,7 @@ class buildkite_agent::install (
       source       => $package_source,
       extract      => true,
       extract_path => "/tmp/${archive_name}-untar",
-      cleanup      => false
+      cleanup      => false,
     }
 
     exec { 'cp_buildkite_agent':

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,18 @@
 {
-  "name": "call-buildkite_agent",
-  "version": "0.1.0",
   "author": "call",
-  "summary": "",
-  "license": "MIT",
-  "source": "",
   "dependencies": [
-
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 4.4.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 6.2.0 < 7.0.0"
+    }
   ],
+  "issues_url": "https://github.com/call/puppet-buildkite_agent/issues",
+  "license": "MIT",
+  "name": "call-buildkite_agent",
   "operatingsystem_support": [
     {
       "operatingsystem": "Darwin",
@@ -16,13 +21,17 @@
       ]
     }
   ],
+  "pdk-version": "1.15.0",
+  "project_page": "https://github.com/call/puppet-buildkite_agent",
   "requirements": [
     {
       "name": "puppet",
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.15.0",
+  "source": "https://github.com/call/puppet-buildkite_agent",
+  "summary": "A puppet module for managing Buildkite agents.",
+  "template-ref": "tags/1.15.0-0-g0bc522e",
   "template-url": "pdk-default#1.15.0",
-  "template-ref": "tags/1.15.0-0-g0bc522e"
+  "version": "0.1.0"
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'buildkite_agent::install' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
This PR encapsulates the following changes:

- Update `metadata.json` beyond boilerplate. Add `dependencies`, `issues_url`, `summary`, `source`.
- Add `.rubocop.yml` from [puppetlabs/puppet](https://github.com/puppetlabs/puppet/blob/master/.rubocop.yml) to silence `pdk validate` warnings on boilerplate.
- Create `buildkite_agent::install` class