### PR TITLE
Manage buildkite agent token

### DIFF
--- a/.github/workflows/forge_publish.yml
+++ b/.github/workflows/forge_publish.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Publish to Puppet Forge
       uses: call/dockerfile-curl@master
       with:
-        args: '-D- --fail --silent --show-error --request POST "https://forgeapi.puppet.com/v3/releases" -F "file=@pkg/module.tar.gz" -H "Authorization: Bearer ${{ secrets. FORGE_API_KEY }}"'
+        args: '-D- --fail --silent --show-error --request POST "https://forgeapi.puppet.com/v3/releases" -F "file=@pkg/module.tar.gz" -H "Authorization: Bearer ${{ secrets.FORGE_API_KEY }}"'

--- a/.github/workflows/macos_puppet_apply.yml
+++ b/.github/workflows/macos_puppet_apply.yml
@@ -32,11 +32,11 @@ jobs:
 
         echo "Running puppet apply (1 of 2)..."
         sudo /opt/puppetlabs/puppet/bin/puppet apply -e \
-          'buildkite_agent{ "token" => "${{ secrets.BUILDKITE_AGENT_TOKEN }}" }'
+          "class { 'buildkite_agent': token => '${{ secrets.BUILDKITE_AGENT_TOKEN }}' }"
 
         echo "Running puppet apply (2 of 2)..."
         sudo /opt/puppetlabs/puppet/bin/puppet apply -e \
-          'buildkite_agent{ "token" => "${{ secrets.BUILDKITE_AGENT_TOKEN }}" }'
+          "class { 'buildkite_agent': token => '${{ secrets.BUILDKITE_AGENT_TOKEN }}' }"
 
         ## Test
         gem install bundler

--- a/.github/workflows/macos_puppet_apply.yml
+++ b/.github/workflows/macos_puppet_apply.yml
@@ -31,10 +31,12 @@ jobs:
         sudo /opt/puppetlabs/puppet/bin/puppet module install ../module.tar.gz
 
         echo "Running puppet apply (1 of 2)..."
-        sudo /opt/puppetlabs/puppet/bin/puppet apply -e "include buildkite_agent"
+        sudo /opt/puppetlabs/puppet/bin/puppet apply -e \
+          "buildkite_agent{ 'token' => '${{ secrets.BUILDKITE_AGENT_TOKEN }}' }"
 
         echo "Running puppet apply (2 of 2)..."
-        sudo /opt/puppetlabs/puppet/bin/puppet apply -e "include buildkite_agent"
+        sudo /opt/puppetlabs/puppet/bin/puppet apply -e \
+          "buildkite_agent{ 'token' => '${{ secrets.BUILDKITE_AGENT_TOKEN }}' }"
 
         ## Test
         gem install bundler

--- a/.github/workflows/macos_puppet_apply.yml
+++ b/.github/workflows/macos_puppet_apply.yml
@@ -32,15 +32,16 @@ jobs:
 
         echo "Running puppet apply (1 of 2)..."
         sudo /opt/puppetlabs/puppet/bin/puppet apply -e \
-          "buildkite_agent{ 'token' => '${{ secrets.BUILDKITE_AGENT_TOKEN }}' }"
+          'buildkite_agent{ "token" => "${{ secrets.BUILDKITE_AGENT_TOKEN }}" }'
 
         echo "Running puppet apply (2 of 2)..."
         sudo /opt/puppetlabs/puppet/bin/puppet apply -e \
-          "buildkite_agent{ 'token' => '${{ secrets.BUILDKITE_AGENT_TOKEN }}' }"
+          'buildkite_agent{ "token" => "${{ secrets.BUILDKITE_AGENT_TOKEN }}" }'
 
         ## Test
         gem install bundler
-        cd test && bundle install && rake
+        cd test && bundle install --quiet --force --jobs=4
+        rake
 
         echo "Catting buildkite-agent log"
         cat ~/.buildkite-agent/log/buildkite-agent.log

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,7 +49,7 @@ define buildkite_agent::config (
   Optional[Boolean] $tags_from_gcp_labels          = undef,
   Optional[Boolean] $tags_from_host                = undef,
   Optional[Boolean] $timestamp_lines               = undef,
-  Optional[String] $token                          = undef,
+  Optional[String] $token                          = $::buildkite_agent::token,
   Optional[String] $wait_for_ec2_tags_timeout      = undef,
   Optional[String] $wait_for_gcp_labels_timeout    = undef,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 # @example
 #   include buildkite_agent
 class buildkite_agent (
+  String[1] $token,
   Optional[Hash[String, Hash[String, Variant[String, Integer, Boolean]]]] $configs,
   Optional[Hash[String, Hash[String, Variant[String, Integer, Boolean]]]] $services,
 ) {

--- a/test/spec/localhost/mac_spec.rb
+++ b/test/spec/localhost/mac_spec.rb
@@ -55,6 +55,12 @@ describe file("/Users/#{USER}/.buildkite-agent/log/buildkite-agent.log") do
   it { should be_owned_by "#{USER}" }
   it { should be_grouped_into 'staff' }
   it { should be_mode 644 }
+  its(:content) { should contain 'Starting buildkite-agent' }
+  its(:content) { should contain 'Configuration loaded' }
+  its(:content) { should contain 'Registering agent with Buildkite' }
+  its(:content) { should contain 'Successfully registered agent' }
+  its(:content) { should contain 'Connecting to Buildkite' }
+  its(:content) { should contain 'Waiting for work' }
 end
 
 describe file("/Users/#{USER}/.buildkite-agent/buildkite-agent.cfg") do


### PR DESCRIPTION
This PR encapsulates the following changes:

- Fix errant whitespace in `${{ secrets.FORGE_API_KEY }}` in `forge_publish.yml` workflow
- Add Buildkite Agent token parameter to `::buildkite_agent` class
- Pass token (stored as [GitHub encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)) as param in `::buildkite_agent` class declaration in `macos_puppet_apply.yml` workflow
- Add tests for log file contents on successful startup

---

Here is the result—a buildkite agent provisioned inside GitHub Actions, connected to the `call` Buildkite org.

<img width="716" alt="Screen Shot 2020-02-10 at 1 52 14 PM" src="https://user-images.githubusercontent.com/6537446/74194971-265beb00-4c0f-11ea-824c-9988dd09a8e8.png">
