### PR TITLE
Remove deprecated --force flag from bundle install

### DIFF
--- a/.github/workflows/macos_puppet_apply.yml
+++ b/.github/workflows/macos_puppet_apply.yml
@@ -40,7 +40,7 @@ jobs:
 
         ## Test
         gem install bundler
-        cd test && bundle install --quiet --force --jobs=4
+        cd test && bundle install --quiet --jobs=4
         rake
 
         echo "Catting buildkite-agent log"


### PR DESCRIPTION
Bundle install provides the following message when using the `--force` flag:

```
[DEPRECATED] The `--force` option has been renamed to `--redownload`
```

This is altogether unneeded in our testing environment, as we're always setting up the dependencies from scratch.