### PR TITLE
Add README

### DIFF
--- a/.github/workflows/macos_puppet_apply.yml
+++ b/.github/workflows/macos_puppet_apply.yml
@@ -42,6 +42,3 @@ jobs:
         gem install bundler
         cd test && bundle install --quiet --jobs=4
         rake
-
-        echo "Catting buildkite-agent log"
-        cat ~/.buildkite-agent/log/buildkite-agent.log

--- a/.github/workflows/macos_qa.yml
+++ b/.github/workflows/macos_qa.yml
@@ -1,4 +1,4 @@
-name: MacOS puppet apply
+name: MacOS QA
 on: [push]
 jobs:
   pdk:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Two [GitHub Actions](https://help.github.com/en/actions) workflows are used in t
   - Run `pdk build` to [build the module package](https://puppet.com/docs/pdk/1.x/pdk_building_module_packages.html)
   - Publish module package to the [Puppet Forge](https://forge.puppet.com/) using the [Forge API](https://puppet.com/blog/new-forge-api-endpoints-automating-module-management/)
     - `FORGE_API_KEY` must be set as a GitHub Actions [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
-- `macos_puppet_apply.yml`
+- `macos_qa.yml`
   - Triggered on every push
   - Install `puppet-agent-6` from package at [downloads.puppet.com/mac/puppet6/10.14/x86_64/](https://downloads.puppet.com/mac/puppet6/10.14/x86_64/)
   - Build the module package from source with `tar`

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Replace the value for `token` with your Buildkite [Agent Token](https://buildkit
 
 ## Usage
 
-:bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the value returned by the custom fact `lib/facter/primary_user.rb` will be used as the default.
+To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the example above (with your own token).
 
-To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the _Beginning with buildkite_agent_ example above.
+:bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the user with greatest login time, as determined by the custom fact `lib/facter/primary_user.rb`, will be used as the default.
 
 TODO: Add advanced usage examples
 
@@ -57,7 +57,7 @@ This module only supports macOS, and has only been tested on macOS Catalina (10.
 
 ## Development
 
-TODO: Figure out how to safely contribute with GitHub Actions + PRs
+TODO: Figure out how to safely accept public contributions with GitHub Actions + PRs
 
 ## Testing
 
@@ -65,11 +65,9 @@ This module is tested by
 
 - Installing `puppet-agent` and this module in a GitHub Actions macOS environment
 - Running `puppet apply` (2x) to check that desired state is configured and maintained
-- Validating configuration with [Serverspec](https://serverspec.org/) tests
+- Validating configuration with [Serverspec](https://serverspec.org/) tests (located in the `test/` directory)
 
 GitHub Actions macOS virtual environments are hosted on [MacStadium](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#cloud-hosts-for-github-hosted-runners) and contain some [preconfigured software](https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners#macos-1015).
-
-All Serverspec tests are located in the `test/` directory.
 
 TODO: Add Puppet spec tests
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 
 A Puppet module to manage Buildkite Agent services on macOS nodes.
 
-#### Table of Contents
+## Table of Contents
 
 - [buildkite_agent](#buildkiteagent)
-      - [Table of Contents](#table-of-contents)
+  - [Table of Contents](#table-of-contents)
   - [Description](#description)
   - [Setup](#setup)
     - [What buildkite_agent affects](#what-buildkiteagent-affects)
     - [Setup Requirements](#setup-requirements)
     - [Beginning with buildkite_agent](#beginning-with-buildkiteagent)
-      - [Without Hiera](#without-hiera)
-      - [With Hiera](#with-hiera)
   - [Usage](#usage)
   - [Reference](#reference)
   - [Limitations](#limitations)
@@ -33,9 +31,9 @@ This module currently supports only macOS.
 
 ### What buildkite_agent affects
 
-* Download and installation of the `buildkite-agent` `tar` archive from GitHub.
-* Management of multiple Buildkite Agent configuration files
-* Management of multiple Buildkite Agent `launchd` jobs
+- Download and installation `buildkite-agent` binary from GitHub release tarball
+- Management of one or more Buildkite Agent configuration files
+- Management of one or more Buildkite Agent `launchd` jobs
 
 ### Setup Requirements
 
@@ -43,31 +41,19 @@ This module depends on the `puppetlabs/stdlib` and `puppet/archive` modules.
 
 ### Beginning with buildkite_agent
 
-#### Without Hiera
-
-```puppet
-include buildkite_agent::install
-
-buildkite_agent::config { 'primary':
-  config_file_path => '/usr/local/etc/buildkite-agent/buildkite-agent.cfg',
-]
-
-buildkite_agent::service { 'primary':
-  user => 'call',
-}
-```
-
-#### With Hiera
-
 ```puppet
 include buildkite_agent
 ```
 
 ## Usage
 
+:warning: This section is incomplete.
+
 Include usage examples for common use cases in the **Usage** section. Show your users how to use your module to solve problems, and be sure to include code examples. Include three to five examples of the most important or common tasks a user can accomplish with your module. Show users how to accomplish more complex tasks that involve different types, classes, and functions working in tandem.
 
 ## Reference
+
+:warning: This section is incomplete.
 
 This section is deprecated. Instead, add reference information to your code as Puppet Strings comments, and then use Strings to generate a REFERENCE.md in your module. For details on how to add code comments and generate documentation with Strings, see the Puppet Strings [documentation](https://puppet.com/docs/puppet/latest/puppet_strings.html) and [style guide](https://puppet.com/docs/puppet/latest/puppet_strings_style.html)
 
@@ -75,14 +61,14 @@ If you aren't ready to use Strings yet, manually create a REFERENCE.md in the ro
 
 For each element (class, defined type, function, and so on), list:
 
-  * The data type, if applicable.
-  * A description of what the element does.
-  * Valid values, if the data type doesn't make it obvious.
-  * Default value, if any.
+- The data type, if applicable.
+- A description of what the element does.
+- Valid values, if the data type doesn't make it obvious.
+- Default value, if any.
 
 For example:
 
-```
+```bash
 ### `pet::cat`
 
 #### Parameters
@@ -96,12 +82,18 @@ Default: 'medium-loud'.
 
 ## Limitations
 
+:warning: This section is incomplete.
+
 In the Limitations section, list any incompatibilities, known issues, or other warnings.
 
 ## Development
 
+:warning: This section is incomplete.
+
 In the Development section, tell other users the ground rules for contributing to your project and how they should submit their work.
 
 ## Release Notes/Contributors/Etc. **Optional**
+
+:warning: This section is incomplete.
 
 If you aren't using changelog, put your release notes here (though you should consider using changelog). You can also add any additional sections you feel are necessary or important to include here. Please use the `## ` header.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Replace the value for `token` with your Buildkite [Agent Token](https://buildkit
 
 To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the examples above.
 
-:bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the user with greatest login time, as determined by the custom fact `lib/facter/primary_user.rb`, will be used as the default.
+:bulb:  The `buildkite_agent::config::user` and `buildkite_agent::service::user` parameters use the `primary_user` custom fact, included with this module, as the default value.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Two [GitHub Actions](https://help.github.com/en/actions) workflows are used in t
   - Run `pdk build` to [build the module package](https://puppet.com/docs/pdk/1.x/pdk_building_module_packages.html)
   - Publish module package to the [Puppet Forge](https://forge.puppet.com/) using the [Forge API](https://puppet.com/blog/new-forge-api-endpoints-automating-module-management/)
     - `FORGE_API_KEY` must be set as a GitHub Actions [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
-- `macos_pupet_apply.yml`
+- `macos_puppet_apply.yml`
   - Triggered on every push
   - Install `puppet-agent-6` from package at [downloads.puppet.com/mac/puppet6/10.14/x86_64/](https://downloads.puppet.com/mac/puppet6/10.14/x86_64/)
   - Build the module package from source with `tar`

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # buildkite_agent
 
-Welcome to your new module. A short overview of the generated parts can be found in the PDK documentation at https://puppet.com/pdk/latest/pdk_generating_modules.html .
+:warning: This module is in active development.
 
-The README template below provides a starting point with details about what information to include in your README.
+A Puppet module to manage Buildkite Agent services on macOS nodes.
 
 #### Table of Contents
 
-1. [Description](#description)
-2. [Setup - The basics of getting started with buildkite_agent](#setup)
-    * [What buildkite_agent affects](#what-buildkite_agent-affects)
-    * [Setup requirements](#setup-requirements)
-    * [Beginning with buildkite_agent](#beginning-with-buildkite_agent)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Limitations - OS compatibility, etc.](#limitations)
-5. [Development - Guide for contributing to the module](#development)
+- [buildkite_agent](#buildkiteagent)
+      - [Table of Contents](#table-of-contents)
+  - [Description](#description)
+  - [Setup](#setup)
+    - [What buildkite_agent affects **OPTIONAL**](#what-buildkiteagent-affects-optional)
+    - [Setup Requirements **OPTIONAL**](#setup-requirements-optional)
+    - [Beginning with buildkite_agent](#beginning-with-buildkiteagent)
+  - [Usage](#usage)
+  - [Reference](#reference)
+  - [Limitations](#limitations)
+  - [Development](#development)
+  - [Release Notes/Contributors/Etc. **Optional**](#release-notescontributorsetc-optional)
 
 ## Description
 
-Briefly tell users why they might want to use your module. Explain what your module does and what kind of problems users can solve with it.
+Buildkite Agent is a small Go binary used to run Buildkite jobs. A single physical or virtual host can run multiple, independently configured Buildkite Agent services. This module is designed for use with Hiera. Settings for Buildkite Agent services can be defined as Hiera hashes, providing a data-driven mechanism for managing complex configurations of multiple Buildkite Agents.
 
-This should be a fairly short description helps the user decide if your module is what they want.
+This module currently supports only macOS.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,19 @@ To run a single Buildkite Agent with the default LaunchAgent label of `com.build
 
 :bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the user with greatest login time, as determined by the custom fact `lib/facter/primary_user.rb`, will be used as the default.
 
-TODO: Add advanced usage examples
-
 ## Limitations
 
 This module only supports macOS, and has only been tested on macOS Catalina (10.15).
 
 ## Development
 
-TODO: Figure out how to safely accept public contributions with GitHub Actions + PRs
+This module is developed using the Puppet Development Kit (PDK).
+
+To contribute:
+
+1. Fork this repository
+2. Make changes
+3. Create a pull request
 
 ## Testing
 
@@ -78,15 +82,13 @@ This module is tested using the following steps:
 
 GitHub Actions macOS virtual environments are hosted on [MacStadium](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#cloud-hosts-for-github-hosted-runners) and contain some [preconfigured software](https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners#macos-1015).
 
-TODO: Add Puppet spec tests
-
 ## GitHub Actions
 
 Two [GitHub Actions](https://help.github.com/en/actions) workflows are used in the development and publishing of this module. GitHub Actions workflows are located in the `.github/workflows/` directory .
 
 - `forge_publish.yml`
   - Triggered when a [SemVer](https://semver.org/)-style tag is pushed on any branch
-  - Run all Puppet Development Kit (PDK) [validations](https://puppet.com/docs/pdk/1.x/pdk_testing.html#validate-module) against this repository
+  - Run all PDK [validations](https://puppet.com/docs/pdk/1.x/pdk_testing.html#validate-module) against this repository
   - Run `pdk build` to [build the module package](https://puppet.com/docs/pdk/1.x/pdk_building_module_packages.html)
   - Publish module package to the [Puppet Forge](https://forge.puppet.com/) using the [Forge API](https://puppet.com/blog/new-forge-api-endpoints-automating-module-management/)
     - `FORGE_API_KEY` must be set as a GitHub Actions [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Puppet module to manage [Buildkite Agent](https://buildkite.com/docs/agent/v3)
 
 Buildkite Agent (`buildkite-agent`) is a small Go binary that runs [Buildkite](https://buildkite.com) jobs.
 
-The `buildkite_agent` Puppet module
+The `buildkite_agent` Puppet module:
 
 - Installs `buildkite-agent` from GitHub [release](https://github.com/buildkite/agent/releases) tarball
 - Manages Buildkite Agent [config files and settings](https://buildkite.com/docs/agent/v3/configuration)
@@ -61,11 +61,11 @@ TODO: Figure out how to safely accept public contributions with GitHub Actions +
 
 ## Testing
 
-This module is tested by
+This module is tested using the following steps:
 
-- Installing `puppet-agent` and this module in a GitHub Actions macOS environment
-- Running `puppet apply` (2x) to check that desired state is configured and maintained
-- Validating configuration with [Serverspec](https://serverspec.org/) tests (located in the `test/` directory)
+- Install `puppet-agent` and this module in a GitHub Actions macOS environment
+- Run `puppet apply` (2x) to check that desired state is configured and maintained
+- Validate configuration with [Serverspec](https://serverspec.org/) tests (located in the `test/` directory)
 
 GitHub Actions macOS virtual environments are hosted on [MacStadium](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#cloud-hosts-for-github-hosted-runners) and contain some [preconfigured software](https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners#macos-1015).
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ A Puppet module to manage Buildkite Agent services on macOS nodes.
       - [Table of Contents](#table-of-contents)
   - [Description](#description)
   - [Setup](#setup)
-    - [What buildkite_agent affects **OPTIONAL**](#what-buildkiteagent-affects-optional)
-    - [Setup Requirements **OPTIONAL**](#setup-requirements-optional)
+    - [What buildkite_agent affects](#what-buildkiteagent-affects)
+    - [Setup Requirements](#setup-requirements)
     - [Beginning with buildkite_agent](#beginning-with-buildkiteagent)
+      - [Without Hiera](#without-hiera)
+      - [With Hiera](#with-hiera)
   - [Usage](#usage)
   - [Reference](#reference)
   - [Limitations](#limitations)
@@ -21,31 +23,45 @@ A Puppet module to manage Buildkite Agent services on macOS nodes.
 
 ## Description
 
-Buildkite Agent is a small Go binary used to run Buildkite jobs. A single physical or virtual host can run multiple, independently configured Buildkite Agent services. This module is designed for use with Hiera. Settings for Buildkite Agent services can be defined as Hiera hashes, providing a data-driven mechanism for managing complex configurations of multiple Buildkite Agents.
+Buildkite Agent is a small Go binary used to run jobs from [Buildkite](https://buildkite.com). A single physical or virtual host can run multiple, independently configured Buildkite Agent services.
+
+This module is designed for use with Hiera. Settings for Buildkite Agent services can be defined as Hiera hashes, providing a data-driven mechanism for managing complex configurations of multiple Buildkite Agents.
 
 This module currently supports only macOS.
 
 ## Setup
 
-### What buildkite_agent affects **OPTIONAL**
+### What buildkite_agent affects
 
-If it's obvious what your module touches, you can skip this section. For example, folks can probably figure out that your mysql_instance module affects their MySQL instances.
+* Download and installation of the `buildkite-agent` `tar` archive from GitHub.
+* Management of multiple Buildkite Agent configuration files
+* Management of multiple Buildkite Agent `launchd` jobs
 
-If there's more that they should know about, though, this is the place to mention:
+### Setup Requirements
 
-* Files, packages, services, or operations that the module will alter, impact, or execute.
-* Dependencies that your module automatically installs.
-* Warnings or other important notices.
-
-### Setup Requirements **OPTIONAL**
-
-If your module requires anything extra before setting up (pluginsync enabled, another module, etc.), mention it here.
-
-If your most recent release breaks compatibility or requires particular steps for upgrading, you might want to include an additional "Upgrading" section here.
+This module depends on the `puppetlabs/stdlib` and `puppet/archive` modules.
 
 ### Beginning with buildkite_agent
 
-The very basic steps needed for a user to get the module up and running. This can include setup steps, if necessary, or it can be an example of the most basic use of the module.
+#### Without Hiera
+
+```puppet
+include buildkite_agent::install
+
+buildkite_agent::config { 'primary':
+  config_file_path => '/usr/local/etc/buildkite-agent/buildkite-agent.cfg',
+]
+
+buildkite_agent::service { 'primary':
+  user => 'call',
+}
+```
+
+#### With Hiera
+
+```puppet
+include buildkite_agent
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buildkite_agent
 
-A Puppet module to manage Buildkite Agent on macOS.
+A Puppet module to manage [Buildkite Agent](https://buildkite.com/docs/agent/v3) on macOS. :apple:
 
 ## Table of Contents
 
@@ -8,94 +8,87 @@ A Puppet module to manage Buildkite Agent on macOS.
   - [Table of Contents](#table-of-contents)
   - [Description](#description)
   - [Setup](#setup)
-    - [What buildkite_agent affects](#what-buildkiteagent-affects)
-    - [Setup Requirements](#setup-requirements)
     - [Beginning with buildkite_agent](#beginning-with-buildkiteagent)
   - [Usage](#usage)
-  - [Reference](#reference)
   - [Limitations](#limitations)
   - [Development](#development)
-  - [Release Notes/Contributors/Etc. **Optional**](#release-notescontributorsetc-optional)
+  - [Testing](#testing)
+  - [GitHub Actions](#github-actions)
 
 ## Description
 
-[`buildkite-agent`](https://buildkite.com/docs/agent/v3) is a small Go binary that runs [Buildkite](https://buildkite.com) jobs.
+Buildkite Agent (`buildkite-agent`) is a small Go binary that runs [Buildkite](https://buildkite.com) jobs.
 
 The `buildkite_agent` Puppet module
 
-- Installs `buildkite-agent` from GitHub release tarball
+- Installs `buildkite-agent` from GitHub [release](https://github.com/buildkite/agent/releases) tarball
 - Manages Buildkite Agent [config files and settings](https://buildkite.com/docs/agent/v3/configuration)
-- Manages Buildkite Agent [launchd](https://www.launchd.info/) user agents
+- Manages Buildkite Agent user [LaunchAgents](https://github.com/buildkite/agent/blob/master/templates/launchd_local_with_gui.plist) ([launchd](https://www.launchd.info/) jobs)
 
-This module currently supports __macOS only__. :apple:
+Classes and defined types use default parameter values sourced from Buildkite's [macOS agent documentation](https://buildkite.com/docs/agent/v3/osx).
+
+This module currently supports __macOS only__.
 
 ## Setup
 
-### What buildkite_agent affects
-
-- Download and installation `buildkite-agent` binary from GitHub release tarball
-- Management of multiple Buildkite Agent config files and [`launchd`](https://www.launchd.info/) user agents
-- Management of multiple Buildkite Agent `launchd` jobs
-
-### Setup Requirements
-
-This module depends on the `puppetlabs/stdlib` and `puppet/archive` modules.
-
 ### Beginning with buildkite_agent
 
+Setting the `token` parameter is the only requirement to get up and running.
+
 ```puppet
-include buildkite_agent
+class { 'buildkite_agent':
+  token => '757613ad20dfaf9b7b4b37d0b4ed4b6c',
+}
 ```
+
+Replace the value for `token` with your Buildkite [Agent Token](https://buildkite.com/docs/agent/v3/tokens).
 
 ## Usage
 
-:warning: This section is incomplete.
+:bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the value returned by the custom fact `lib/facter/primary_user.rb` will be used as the default.
 
-Include usage examples for common use cases in the **Usage** section. Show your users how to use your module to solve problems, and be sure to include code examples. Include three to five examples of the most important or common tasks a user can accomplish with your module. Show users how to accomplish more complex tasks that involve different types, classes, and functions working in tandem.
+To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the _Beginning with buildkite_agent_ example above.
 
-## Reference
-
-:warning: This section is incomplete.
-
-This section is deprecated. Instead, add reference information to your code as Puppet Strings comments, and then use Strings to generate a REFERENCE.md in your module. For details on how to add code comments and generate documentation with Strings, see the Puppet Strings [documentation](https://puppet.com/docs/puppet/latest/puppet_strings.html) and [style guide](https://puppet.com/docs/puppet/latest/puppet_strings_style.html)
-
-If you aren't ready to use Strings yet, manually create a REFERENCE.md in the root of your module directory and list out each of your module's classes, defined types, facts, functions, Puppet tasks, task plans, and resource types and providers, along with the parameters for each.
-
-For each element (class, defined type, function, and so on), list:
-
-- The data type, if applicable.
-- A description of what the element does.
-- Valid values, if the data type doesn't make it obvious.
-- Default value, if any.
-
-For example:
-
-```bash
-### `pet::cat`
-
-#### Parameters
-
-##### `meow`
-
-Enables vocalization in your cat. Valid options: 'string'.
-
-Default: 'medium-loud'.
-```
+TODO: Add advanced usage examples
 
 ## Limitations
 
-:warning: This section is incomplete.
-
-In the Limitations section, list any incompatibilities, known issues, or other warnings.
+This module only supports macOS, and has only been tested on macOS Catalina (10.15).
 
 ## Development
 
-:warning: This section is incomplete.
+TODO: Figure out how to safely contribute with GitHub Actions + PRs
 
-In the Development section, tell other users the ground rules for contributing to your project and how they should submit their work.
+## Testing
 
-## Release Notes/Contributors/Etc. **Optional**
+This module is tested by
 
-:warning: This section is incomplete.
+- Installing `puppet-agent` and this module in a GitHub Actions macOS environment
+- Running `puppet apply` (2x) to check that desired state is configured and maintained
+- Validating configuration with [Serverspec](https://serverspec.org/) tests
 
-If you aren't using changelog, put your release notes here (though you should consider using changelog). You can also add any additional sections you feel are necessary or important to include here. Please use the `## ` header.
+GitHub Actions macOS virtual environments are hosted on [MacStadium](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#cloud-hosts-for-github-hosted-runners) and contain some [preconfigured software](https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners#macos-1015).
+
+All Serverspec tests are located in the `test/` directory.
+
+TODO: Add Puppet spec tests
+
+## GitHub Actions
+
+Two [GitHub Actions](https://help.github.com/en/actions) workflows are used in the development and publishing of this module. GitHub Actions workflows are located in the `.github/workflows/` directory .
+
+- `forge_publish.yml`
+  - Triggered when a [SemVer](https://semver.org/)-style tag is pushed on any branch
+  - Run all Puppet Development Kit (PDK) [validations](https://puppet.com/docs/pdk/1.x/pdk_testing.html#validate-module) against this repository
+  - Run `pdk build` to [build the module package](https://puppet.com/docs/pdk/1.x/pdk_building_module_packages.html)
+  - Publish module package to the [Puppet Forge](https://forge.puppet.com/) using the [Forge API](https://puppet.com/blog/new-forge-api-endpoints-automating-module-management/)
+    - `FORGE_API_KEY` must be set as a GitHub Actions [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
+- `macos_pupet_apply.yml`
+  - Triggered on every push
+  - Install `puppet-agent-6` from package at downloads.puppet.com/mac/puppet6/10.14/x86_64/
+  - Build the module package from source with `tar`
+  - Install the module with `sudo puppet module install`
+  - Run `puppet apply -e` (2x) to [execute inline code](https://www.puppetcookbook.com/posts/simple-adhoc-execution-with-apply-execute.html) declaring the `buildkite_agent` class
+    - `BUILDKITE_AGENT_TOKEN` must be provided as a GitHub Actions encrypted secret
+  - Install Serverspec gem
+  - Run Serverspec tests

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The `buildkite_agent` Puppet module:
 
 - Installs `buildkite-agent` from GitHub [release](https://github.com/buildkite/agent/releases) tarball
 - Manages Buildkite Agent [config files and settings](https://buildkite.com/docs/agent/v3/configuration)
-- Manages Buildkite Agent user [LaunchAgents](https://github.com/buildkite/agent/blob/master/templates/launchd_local_with_gui.plist) ([launchd](https://www.launchd.info/) jobs)
+- Manages Buildkite Agent user [LaunchAgents](https://github.com/buildkite/agent/blob/master/templates/launchd_local_with_gui.plist)
 
 Classes and defined types use default parameter values sourced from Buildkite's [macOS agent documentation](https://buildkite.com/docs/agent/v3/osx).
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,26 @@ This module currently supports __macOS only__.
 
 Setting the `token` parameter is the only requirement to get up and running.
 
-```puppet
-class { 'buildkite_agent':
-  token => '757613ad20dfaf9b7b4b37d0b4ed4b6c',
-}
-```
+- In-manifest
+
+  ```puppet
+  class { 'buildkite_agent':
+    token => '757613ad20dfaf9b7b4b37d0b4ed4b6c',
+  }
+  ```
+
+- Standalone
+
+  ```bash
+  sudo puppet module install call-buildkite_agent && \
+  sudo puppet apply -e "class {'buildkite_agent': token => '757613ad20dfaf9b7b4b37d0b4ed4b6c'}"
+  ```
 
 Replace the value for `token` with your Buildkite [Agent Token](https://buildkite.com/docs/agent/v3/tokens).
 
 ## Usage
 
-To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the example above.
+To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the examples above.
 
 :bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the user with greatest login time, as determined by the custom fact `lib/facter/primary_user.rb`, will be used as the default.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # buildkite_agent
 
-A Puppet module to manage [Buildkite Agent](https://buildkite.com/docs/agent/v3) on macOS. :apple:
+![](https://github.com/call/puppet-buildkite_agent/workflows/.github/workflows/macos_puppet_apply.yml/badge.svg)
+
+A Puppet module to manage [Buildkite Agent](https://buildkite.com/docs/agent/v3) on macOS.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A Puppet module to manage [Buildkite Agent](https://buildkite.com/docs/agent/v3)
 
 ## Table of Contents
 
-- [buildkite_agent](#buildkiteagent)
+- [buildkite_agent](#buildkite_agent)
   - [Table of Contents](#table-of-contents)
   - [Description](#description)
   - [Setup](#setup)
-    - [Beginning with buildkite_agent](#beginning-with-buildkiteagent)
+    - [Beginning with buildkite_agent](#beginning-with-buildkite_agent)
   - [Usage](#usage)
   - [Limitations](#limitations)
   - [Development](#development)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # buildkite_agent
 
-:warning: This module is in active development.
-
-A Puppet module to manage Buildkite Agent services on macOS nodes.
+A Puppet module to manage Buildkite Agent on macOS.
 
 ## Table of Contents
 
@@ -21,19 +19,24 @@ A Puppet module to manage Buildkite Agent services on macOS nodes.
 
 ## Description
 
-Buildkite Agent is a small Go binary used to run jobs from [Buildkite](https://buildkite.com). A single physical or virtual host can run multiple, independently configured Buildkite Agent services.
+[`buildkite-agent`](https://buildkite.com/docs/agent/v3) is a small Go binary that runs [Buildkite](https://buildkite.com) jobs.
 
-This module is designed for use with Hiera. Settings for Buildkite Agent services can be defined as Hiera hashes, providing a data-driven mechanism for managing complex configurations of multiple Buildkite Agents.
+The `buildkite_agent` module
 
-This module currently supports only macOS.
+- Installs `buildkite-agent` from GitHub release tarball
+- Manages Buildkite Agent [config files and settings](https://buildkite.com/docs/agent/v3/configuration)
+- Manages Buildkite Agent [launchd](https://www.launchd.info/) user agents
+
+
+This module currently supports macOS only. :apple:
 
 ## Setup
 
 ### What buildkite_agent affects
 
 - Download and installation `buildkite-agent` binary from GitHub release tarball
-- Management of one or more Buildkite Agent configuration files
-- Management of one or more Buildkite Agent `launchd` jobs
+- Management of multiple Buildkite Agent config files and [`launchd`](https://www.launchd.info/) user agents
+- Management of multiple Buildkite Agent `launchd` jobs
 
 ### Setup Requirements
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Two [GitHub Actions](https://help.github.com/en/actions) workflows are used in t
     - `FORGE_API_KEY` must be set as a GitHub Actions [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 - `macos_pupet_apply.yml`
   - Triggered on every push
-  - Install `puppet-agent-6` from package at downloads.puppet.com/mac/puppet6/10.14/x86_64/
+  - Install `puppet-agent-6` from package at [downloads.puppet.com/mac/puppet6/10.14/x86_64/](https://downloads.puppet.com/mac/puppet6/10.14/x86_64/)
   - Build the module package from source with `tar`
   - Install the module with `sudo puppet module install`
   - Run `puppet apply -e` (2x) to [execute inline code](https://www.puppetcookbook.com/posts/simple-adhoc-execution-with-apply-execute.html) declaring the `buildkite_agent` class

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Replace the value for `token` with your Buildkite [Agent Token](https://buildkit
 
 ## Usage
 
-To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the example above (with your own token).
+To run a single Buildkite Agent with the default LaunchAgent label of `com.buildkite.buildkite-agent-primary`, use the example above.
 
 :bulb:  If `buildkite_agent::config::user` or `buildkite_agent::service::user` are unspecified, the user with greatest login time, as determined by the custom fact `lib/facter/primary_user.rb`, will be used as the default.
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ A Puppet module to manage Buildkite Agent on macOS.
 
 [`buildkite-agent`](https://buildkite.com/docs/agent/v3) is a small Go binary that runs [Buildkite](https://buildkite.com) jobs.
 
-The `buildkite_agent` module
+The `buildkite_agent` Puppet module
 
 - Installs `buildkite-agent` from GitHub release tarball
 - Manages Buildkite Agent [config files and settings](https://buildkite.com/docs/agent/v3/configuration)
 - Manages Buildkite Agent [launchd](https://www.launchd.info/) user agents
 
-
-This module currently supports macOS only. :apple:
+This module currently supports __macOS only__. :apple:
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buildkite_agent
 
-![](https://github.com/call/puppet-buildkite_agent/workflows/.github/workflows/macos_puppet_apply.yml/badge.svg)
+![](https://github.com/call/puppet-buildkite_agent/workflows/MacOS%20QA/badge.svg)
 
 A Puppet module to manage [Buildkite Agent](https://buildkite.com/docs/agent/v3) on macOS.
 


### PR DESCRIPTION
This PR encapsulates the following changes:
- Remove `cat`ting of the log file from `macos_puppet_apply.yml` workflow—this was for debugging and is no longer needed in `master`
- Add (reasonably) comprehensive README, using [`puppetlabs/ntp`](https://forge.puppet.com/puppetlabs/ntp) and [`puppetlabs/apache`](https://forge.puppet.com/puppetlabs/apache) as best-practice examples
- Change the name of the GitHub Actions workflow from _MacOS puppet apply_ to _MacOS QA_